### PR TITLE
Added http response checking

### DIFF
--- a/lib/src/storage_caching_tile_provider.dart
+++ b/lib/src/storage_caching_tile_provider.dart
@@ -51,7 +51,9 @@ class StorageCachingTileProvider extends TileProvider {
         final cordDouble = Coords(cord.x.toDouble(), cord.y.toDouble());
         cordDouble.z = cord.z.toDouble();
         final url = getTileUrl(cordDouble, options);
-        final bytes = (await http.get(Uri.parse(url))).bodyBytes;
+        final response = await http.get(Uri.parse(url));
+        if (response.statusCode != 200) throw new FormatException();
+        final bytes = response.bodyBytes;
         await TileStorageCachingManager.saveTile(bytes, cord);
       } catch (e) {
         errorsCount++;
@@ -151,7 +153,9 @@ class CachedTileImageProvider extends ImageProvider<Coords<num>> {
             (localBytes?.item2.millisecondsSinceEpoch ?? 0)) >
         cacheValidDuration.inMilliseconds) {
       try {
-        bytes = (await http.get(Uri.parse(url))).bodyBytes;
+        final response = await http.get(Uri.parse(url));
+        if (response.statusCode != 200) throw new FormatException();
+        bytes = response.bodyBytes;
         await TileStorageCachingManager.saveTile(bytes, coords);
       } catch (e) {
         if (netWorkErrorHandler != null) netWorkErrorHandler!(e);


### PR DESCRIPTION
Found that no exceptions are raised if the http.get() function returns a 401 or other http status codes that indicate a failed request. This would have us store the 401 page or other error pages set by the server into our database, which remains there until either we clear the cache or the tiles time out.

I added in some code to check the response from the http.get() function to assure the request statusCode is 200 which indicates a successful response from the server. This was done in both the loadTiles() and _loadAsync() functions so that the same behavior occurs in both cases. Now if the server responds with something other than a valid tile we raise an exception and don't store this data in the database.

Tested both functions in my current application and all seems to be working fine.