### PR TITLE
v4: Increase Bulk Download Speeds

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -581,7 +581,7 @@ class StorageCachingTileProvider extends TileProvider {
       ).then((value) {
         try {
           successfulTiles += value[0] as int;
-          if (value[1] != '') failedTiles.add(value[1]);
+          if (value[1].isNotEmpty) failedTiles.add(value[1]);
           seaTiles += value[2] as int;
           existingTiles += value[3] as int;
         } catch (e) {}

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -560,7 +560,7 @@ class StorageCachingTileProvider extends TileProvider {
     Completer<List> completer = Completer();
 
     int successfulTiles = 0;
-    List<String> failedTiles = [];
+    List<String?> failedTiles = [];
     int seaTiles = 0;
     int existingTiles = 0;
 
@@ -581,7 +581,7 @@ class StorageCachingTileProvider extends TileProvider {
       ).then((value) {
         try {
           successfulTiles += value[0] as int;
-          failedTiles.add(value[1]);
+          if (value[1] != '') failedTiles.add(value[1]);
           seaTiles += value[2] as int;
           existingTiles += value[3] as int;
         } catch (e) {}

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -581,7 +581,7 @@ class StorageCachingTileProvider extends TileProvider {
       ).then((value) {
         try {
           successfulTiles += value[0] as int;
-          failedTiles.addAll(value[1]);
+          failedTiles.add(value[1]);
           seaTiles += value[2] as int;
           existingTiles += value[3] as int;
         } catch (e) {}

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -70,7 +70,8 @@ class StorageCachingTileProvider extends TileProvider {
   /// Defaults to 20000, set to 0 to disable.
   final int maxStoreLength;
 
-  static var maxParallel = 20;
+  /// The number of download threads allowed to run simultaneously.
+  static var maxParallelThreads = 20;
 
   /// Whether to better enforce the `maxStoreLength`
   ///
@@ -557,13 +558,8 @@ class StorageCachingTileProvider extends TileProvider {
     required seaTileBytes,
     required compressionQuality,
   }) {
-    int successfulTiles = 0;
-    List<String> failedTiles = [];
-    int seaTiles = 0;
-    int existingTiles = 0;
-
     final StreamController<List> streamController = StreamController();
-    final queue = Queue(parallel: maxParallel);
+    final queue = Queue(parallel: maxParallelThreads);
 
     tiles.forEach((e) {
       queue
@@ -580,12 +576,6 @@ class StorageCachingTileProvider extends TileProvider {
                 compressionQuality,
               ))
           .then((value) {
-        try {
-          successfulTiles += value[0] as int;
-          if (value[1].isNotEmpty) failedTiles.add(value[1]);
-          seaTiles += value[2] as int;
-          existingTiles += value[3] as int;
-        } catch (e) {}
         streamController.add([
           value[0],
           value[1],

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -560,7 +560,7 @@ class StorageCachingTileProvider extends TileProvider {
     Completer<List> completer = Completer();
 
     int successfulTiles = 0;
-    List<String?> failedTiles = [];
+    List<String> failedTiles = [];
     int seaTiles = 0;
     int existingTiles = 0;
 

--- a/lib/src/regions/circle.dart
+++ b/lib/src/regions/circle.dart
@@ -22,6 +22,7 @@ class CircleRegion extends BaseRegion {
     int minZoom,
     int maxZoom,
     TileLayerOptions options, {
+    int parallelThreads = 10,
     bool preventRedownload = false,
     bool seaTileRemoval = false,
     int compressionQuality = -1,
@@ -35,6 +36,7 @@ class CircleRegion extends BaseRegion {
       options,
       RegionType.circle,
       this,
+      parallelThreads: parallelThreads,
       preventRedownload: preventRedownload,
       seaTileRemoval: seaTileRemoval,
       compressionQuality: compressionQuality,

--- a/lib/src/regions/downloadableRegion.dart
+++ b/lib/src/regions/downloadableRegion.dart
@@ -77,6 +77,13 @@ class DownloadableRegion {
   /// The options used to fetch tiles
   final TileLayerOptions options;
 
+  /// The number of download threads allowed to run simultaneously
+  ///
+  /// This will significatly increase speed, at the expense of faster battery drain. Note that some servers may forbid multithreading, in which case this should be set to 1.
+  ///
+  /// Set to 1 to disable multithreading (download will still be run in seperate isolate). Defaults to 10.
+  final int parallelThreads;
+
   /// Whether to skip downloading tiles that already exist
   ///
   /// Defaults to `false`, so that existing tiles will be updated.
@@ -122,6 +129,7 @@ class DownloadableRegion {
     this.options,
     this.type,
     this.originalRegion, {
+    this.parallelThreads = 10,
     this.preventRedownload = false,
     this.seaTileRemoval = false,
     this.compressionQuality = -1,
@@ -135,6 +143,10 @@ class DownloadableRegion {
         assert(
           minZoom <= maxZoom,
           '`minZoom` should be less than or equal to `maxZoom`',
+        ),
+        assert(
+          parallelThreads >= 1,
+          '`parallelThreads` should be more than or equal to 1. Set to 1 to disable multithreading',
         );
 }
 

--- a/lib/src/regions/line.dart
+++ b/lib/src/regions/line.dart
@@ -101,6 +101,7 @@ class LineRegion extends BaseRegion {
     int minZoom,
     int maxZoom,
     TileLayerOptions options, {
+    int parallelThreads = 10,
     bool preventRedownload = false,
     bool seaTileRemoval = false,
     int compressionQuality = -1,
@@ -115,6 +116,7 @@ class LineRegion extends BaseRegion {
       options,
       RegionType.line,
       this,
+      parallelThreads: parallelThreads,
       preventRedownload: preventRedownload,
       seaTileRemoval: seaTileRemoval,
       compressionQuality: compressionQuality,

--- a/lib/src/regions/rectangle.dart
+++ b/lib/src/regions/rectangle.dart
@@ -17,6 +17,7 @@ class RectangleRegion extends BaseRegion {
     int minZoom,
     int maxZoom,
     TileLayerOptions options, {
+    int parallelThreads = 10,
     bool preventRedownload = false,
     bool seaTileRemoval = false,
     int compressionQuality = -1,
@@ -30,6 +31,7 @@ class RectangleRegion extends BaseRegion {
       options,
       RegionType.rectangle,
       this,
+      parallelThreads: parallelThreads,
       preventRedownload: preventRedownload,
       seaTileRemoval: seaTileRemoval,
       compressionQuality: compressionQuality,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   path: ^1.8.0
   path_provider: ^2.0.3
   permission_handler: ^8.1.6
+  queue: ^3.1.0
 
 dev_dependencies:
   test: ^1.17.11


### PR DESCRIPTION
Vastly increased download speeds by downloading tiles in bulk.

Earlier, downloading 200 tiles (which is a very small area, around 2 MB) would take 30 seconds on a good internet.

Reason was, the code was awaiting each tile to download and save, before moving on to the next one.
The changes proposed download the tiles in bulk, which made my downloads more than 10x faster.

I would prefer to have more frequent progress responses, but this would require a code re-architecture in some sense, which I unfortunately don't have the time for at the moment, but would love to do so, in the future.

For the moment, the current solution works perfectly for me.