### PR TITLE
Added iOS support for directory watching

### DIFF
--- a/lib/src/storage_managers/storage_manager.dart
+++ b/lib/src/storage_managers/storage_manager.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as p show joinAll, split;
 import 'package:path_provider/path_provider.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:watcher/watcher.dart';
 
 import '../main.dart';
 import '../misc/validate.dart';
@@ -163,14 +164,7 @@ class MapCachingManager {
   }) {
     _cacheRequired;
 
-    if (!FileSystemEntity.isWatchSupported) {
-      throw UnsupportedError(
-          'Watching is not supported on the current platform');
-    }
-
-    final Stream<void> stream = parentDirectory
-        .watch(events: fileSystemEvents, recursive: true)
-        .map((_) => null);
+    final Stream<void> stream = DirectoryWatcher(parentDirectory.absolute.path).events.map((_) => null);
 
     return enableDebounce ? stream.debounce(debounceDuration) : stream;
   }
@@ -197,13 +191,8 @@ class MapCachingManager {
   }) {
     _storeRequired;
 
-    if (!FileSystemEntity.isWatchSupported) {
-      throw UnsupportedError(
-          'Watching is not supported on the current platform');
-    }
+    final Stream<void> stream = DirectoryWatcher(storeDirectory!.absolute.path).events.map((_) => null);
 
-    final Stream<void> stream =
-        storeDirectory!.watch(events: fileSystemEvents).map((event) => null);
 
     return enableDebounce ? stream.debounce(debounceDuration) : stream;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   queue: ^3.1.0+1
   stream_transform: ^2.0.0
   vector_math: ^2.1.1
+  watcher: 1.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
Since neither watchStoreChanges or watchCacheChanges work under IOS I added support for that using the [watcher](https://pub.dev/packages/watcher) library.