### PR TITLE
In FMTCImageProvider compare based on both coords and store name

### DIFF
--- a/lib/src/internal/image_provider.dart
+++ b/lib/src/internal/image_provider.dart
@@ -182,7 +182,7 @@ class FMTCImageProvider extends ImageProvider<FMTCImageProvider> {
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
-    return other is FMTCImageProvider && other.coords == coords;
+    return other is FMTCImageProvider && other.coords == coords && other.provider.storeDirectory.storeName == provider.storeDirectory.storeName;
   }
 
   @override


### PR DESCRIPTION
As mentioned by @tonyshkurenko this seems to have fixed the issue, where it won't display more than one layer at a time.