### PR TITLE
Remove 'await' as store is created synchronously using .create()

### DIFF
--- a/quickstart/go.md
+++ b/quickstart/go.md
@@ -52,7 +52,7 @@ Create an isolated space to store tiles and other information to be accessed by 
 <pre class="language-dart" data-title="main.dart"><code class="lang-dart">Future&#x3C;void> main() async {
     WidgetsFlutterBinding.ensureInitialized();   
     await FlutterMapTileCaching.initialise();
-<strong>    await FMTC.instance('mapStore').manage.create();
+<strong>    FMTC.instance('mapStore').manage.create();
 </strong>    // ...
     // runApp(MyApp());
 }


### PR DESCRIPTION
I was receiving the error below following the quickstart instructions. 
> Uses 'await' on an instance of 'void', which is not a subtype of 'Future'. Try removing the 'await' or changing the expression"
 
Removing 'await' resolves the issue. Alternatively, could update .create() to .createAsync() with await.